### PR TITLE
Spawn command support for objects without an overworld prefab

### DIFF
--- a/ChatCommands/ChatCommands/Chat/Commands/SpawnCommandHandler.cs
+++ b/ChatCommands/ChatCommands/Chat/Commands/SpawnCommandHandler.cs
@@ -18,10 +18,8 @@ public class SpawnCommandHandler : IChatCommandHandler
         var successfulParse = Enum.TryParse(fullName, true, out ObjectID objId);
         try
         {
-            
             hasSpawnablePrefab = Manager._instance._ecsManager.ecsPrefabTable.prefabList[0].GetComponent<PugDatabaseAuthoring>().prefabList._items.Where(x => x.name.ToLower().Replace("entity", "") == fullName).Select(x => x.objectInfo.prefabInfos[0].prefab).First() != null;
-            ChatCommandsPlugin.logger.LogInfo($"{fullName} has spawnable prefab: {hasSpawnablePrefab}, successful parse: {successfulParse}");
-        } catch (Exception ex) { hasSpawnablePrefab = true; ChatCommandsPlugin.logger.LogInfo($"{fullName} {ex.Message}"); }
+        } catch (Exception ex) { hasSpawnablePrefab = true; ChatCommandsPlugin.logger.LogError($"{fullName} {ex.Message}"); }
 
         if (!hasSpawnablePrefab)
         {


### PR DESCRIPTION
Added a check to spawn command to see if the entity has an overworld prefab, and if it doesn't to use CreateAndDropEntity instead of CreateEntity. This allows for spawning DroppedItem of IronOre, IronBar, and such, but will default to CreateEntity.